### PR TITLE
[BUGFIX] Correction du listing de channels slack

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,10 @@
 
 async function foundChannel(slackClient, channelName, core) {
-  const channels = await slackClient.conversations.list({
+  const conversationsList = await slackClient.conversations.list({
     types: 'public_channel,private_channel'
-  }).channels
+  })
+
+  const channels = conversationsList.channels
 
   let result = channels.filter(chan => chan.name === channelName)
   let channelId = undefined

--- a/tests/integration/github.test.js
+++ b/tests/integration/github.test.js
@@ -7,7 +7,6 @@ const prListCommit = require('./list-pr-commit')
 const OWNER = 'pix'
 const REPO_NAME = 'monRepo'
 const GIT_SHA = 'master'
-const configFilename = 'api/lib/config.js'
 
 describe('Integration | notify-team-on-config-file-change', function () {
   let github


### PR DESCRIPTION
## :unicorn: Problème

La récupération de la liste de channels depuis slack ne fonctionne pas en raison d'un await sur une non promesse.

## :robot: Proposition

Corriger ce listing en attendant la résolution de la promesse avant d'aller chercher la propriété channels dans la réponse

## :rainbow: Remarques

C'est cassé depuis très longtemps 😭 
https://github.com/1024pix/pix/actions/workflows/check-api-config-changed-dev.yaml?query=is%3Afailure

## :100: Pour tester

Vérifier que les channels sont bien récupérés
